### PR TITLE
panning with middle mouse button

### DIFF
--- a/src/scripts/controllers/canvasController.js
+++ b/src/scripts/controllers/canvasController.js
@@ -238,7 +238,7 @@ export class CanvasController {
 			panning: true,
 			pinchZoom: true,
 			wheelZoom: true,
-			panButton: 2,
+			panButton: 1,
 			oneFingerPan: true,
 			zoomFactor: this.zoomFactor,
 			zoomMin: this.zoomMin,


### PR DESCRIPTION
Hi, thanks for providing CircuiTikZ as GUI - Great work!

From my perspective, panning should be set on the middle mouse button and not the right mouse button.
The right mouse button is IMHO the standard way to open a context menu.