### PR TITLE
add 'number of inputs' parameter to multi-input available logic gates.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
 				"@types/file-saver": "^2.0.7",
 				"@types/text-to-svg": "^3.1.4",
 				"buffer": "^6.0.3",
-				"electron": "^40.4.1",
+				"electron": "^37.2.5",
 				"parcel": "^2.15.4",
 				"path-browserify": "^1.0.1",
 				"posthtml-include": "^2.0.1",
@@ -5130,15 +5130,15 @@
 			"license": "MIT"
 		},
 		"node_modules/electron": {
-			"version": "40.4.1",
-			"resolved": "https://registry.npmjs.org/electron/-/electron-40.4.1.tgz",
-			"integrity": "sha512-N1ZXybQZL8kYemO8vAeh9nrk4mSvqlAO8xs0QCHkXIvRnuB/7VGwEehjvQbsU5/f4bmTKpG+2GQERe/zmKpudQ==",
+			"version": "37.10.3",
+			"resolved": "https://registry.npmjs.org/electron/-/electron-37.10.3.tgz",
+			"integrity": "sha512-3IjCGSjQmH50IbW2PFveaTzK+KwcFX9PEhE7KXb9v5IT8cLAiryAN7qezm/XzODhDRlLu0xKG1j8xWBtZ/bx/g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
 				"@electron/get": "^2.0.0",
-				"@types/node": "^24.9.0",
+				"@types/node": "^22.7.7",
 				"extract-zip": "^2.0.1"
 			},
 			"bin": {
@@ -5686,16 +5686,6 @@
 				"global-agent": "^3.0.0"
 			}
 		},
-		"node_modules/electron/node_modules/@types/node": {
-			"version": "24.10.13",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
-			"integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"undici-types": "~7.16.0"
-			}
-		},
 		"node_modules/electron/node_modules/fs-extra": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -5730,13 +5720,6 @@
 			"bin": {
 				"semver": "bin/semver.js"
 			}
-		},
-		"node_modules/electron/node_modules/undici-types": {
-			"version": "7.16.0",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/electron/node_modules/universalify": {
 			"version": "0.1.2",

--- a/src/scripts/components/nodeSymbolComponent.ts
+++ b/src/scripts/components/nodeSymbolComponent.ts
@@ -31,6 +31,7 @@ import { selectedBoxWidth } from "../utils/selectionHelper"
 export type NodeSymbolSaveObject = NodeSaveObject & {
 	id: string
 	options?: string[]
+	numberInputs?: string
 }
 
 /**
@@ -51,6 +52,9 @@ export class NodeSymbolComponent extends NodeComponent {
 	protected componentVariant: Variant
 
 	protected scaleProperty: SliderProperty
+	protected numberInputsProperty: ChoiceProperty<ChoiceEntry> | null = null
+	protected inputLineGroup: SVG.G | null = null
+	protected inputLineLength: number = 0
 
 	constructor(symbol: ComponentSymbol) {
 		super()
@@ -121,6 +125,38 @@ export class NodeSymbolComponent extends NodeComponent {
 			}
 		}
 
+		// Add number of inputs property for multi-input logic gates
+		const baseVariant = symbol.getVariant([])
+		const inputPins = baseVariant.pins.filter((pin) => /^in \d+$/.test(pin.name))
+		if (inputPins.length >= 2) {
+			const existingOptions = symbol.possibleOptions.length > 0 || symbol.possibleEnumOptions.length > 0
+			if (!existingOptions) {
+				this.properties.add(
+					PropertyCategories.options,
+					new SectionHeaderProperty("Options", undefined, "options:header")
+				)
+			}
+			const choices: ChoiceEntry[] = [
+				{ key: "2", name: "2" },
+				{ key: "3", name: "3" },
+				{ key: "4", name: "4" },
+				{ key: "5", name: "5" },
+				{ key: "7", name: "7" },
+			]
+			this.numberInputsProperty = new ChoiceProperty(
+				"Number of inputs",
+				choices,
+				choices[0],
+				undefined,
+				"options:number_inputs"
+			)
+			this.numberInputsProperty.addChangeListener(() => {
+				this.regenerateInputSnappingPoints()
+				this.update()
+			})
+			this.properties.add(PropertyCategories.options, this.numberInputsProperty)
+		}
+
 		this.componentVariant = symbol.getVariant(this.optionsFromProperties())
 		this.size = new SVG.Point(this.componentVariant.viewBox.w, this.componentVariant.viewBox.h)
 		this.defaultTextPosition = this.componentVariant.textPosition.point.add(this.componentVariant.mid)
@@ -132,6 +168,16 @@ export class NodeSymbolComponent extends NodeComponent {
 		this.referencePosition = this.componentVariant.mid
 		this.visualization.add(this.componentVisualization)
 		this.dragElement = this.componentVisualization
+
+		// Create an overlay group for dynamic input lines (multi-input logic gates)
+		if (this.numberInputsProperty) {
+			this.inputLineGroup = CanvasController.instance.canvas.group()
+			this.inputLineGroup.addClass("input-lines-overlay")
+			this.visualization.add(this.inputLineGroup)
+
+			// Extract input line length from the SVG symbol's path data
+			this.inputLineLength = this.extractInputLineLength()
+		}
 
 		this.addInfo()
 
@@ -198,10 +244,50 @@ export class NodeSymbolComponent extends NodeComponent {
 		this.size = new SVG.Point(this.componentVariant.viewBox.w, this.componentVariant.viewBox.h)
 		this.defaultTextPosition = this.componentVariant.textPosition.point.add(this.componentVariant.mid)
 
-		this.snappingPoints = this.componentVariant.pins.map(
-			(pin) => new SnapPoint(this, pin.name, pin.point.add(this.componentVariant.mid))
-		)
+		this.regenerateInputSnappingPoints()
 		this.update()
+	}
+
+	/**
+	 * Regenerate input snapping points based on the selected number of inputs.
+	 * Only applies to multi-input logic gates that have a numberInputsProperty.
+	 */
+	protected regenerateInputSnappingPoints() {
+		const basePins = this.componentVariant.pins
+		const baseInputPins = basePins.filter((pin) => /^in \d+$/.test(pin.name))
+		if (baseInputPins.length < 2 || !this.numberInputsProperty) {
+			// Use the default pins from the variant
+			this.snappingPoints = basePins.map(
+				(pin) => new SnapPoint(this, pin.name, pin.point.add(this.componentVariant.mid))
+			)
+			return
+		}
+
+		const numInputs = parseInt(this.numberInputsProperty.value.key)
+
+		const outputPins = basePins.filter((pin) => !/^in \d+$/.test(pin.name))
+
+		// Use the existing input pin x-offset and y-spread to interpolate
+		const sortedInputs = baseInputPins.sort((a, b) => a.point.y - b.point.y)
+		const xOffset = sortedInputs[0].point.x
+		const minY = sortedInputs[0].point.y
+		const maxY = sortedInputs[sortedInputs.length - 1].point.y
+
+		// Generate N evenly-spaced input pins
+		const newInputPins: SnapPoint[] = []
+		for (let i = 1; i <= numInputs; i++) {
+			const t = numInputs > 1 ? (i - 1) / (numInputs - 1) : 0.5
+			const y = minY + t * (maxY - minY)
+			const worldPos = new SVG.Point(xOffset, y).add(this.componentVariant.mid)
+			newInputPins.push(new SnapPoint(this, `in ${i}`, worldPos))
+		}
+
+		this.snappingPoints = [
+			...newInputPins,
+			...outputPins.map((pin) => {
+				return new SnapPoint(this, pin.name, pin.point.add(this.componentVariant.mid))
+			}),
+		]
 	}
 
 	public getSnappingInfo(): SnappingInfo {
@@ -214,12 +300,81 @@ export class NodeSymbolComponent extends NodeComponent {
 	public update() {
 		let m = this.getTransformMatrix()
 		this.componentVisualization.transform(m)
+		if (this.inputLineGroup) {
+			this.inputLineGroup.transform(m)
+			this.redrawInputLines()
+		}
 		this._bbox = this.componentVariant.viewBox.transform(m)
 
 		this.updatePositionedLabel()
 
 		this.recalculateSelectionVisuals()
 		this.recalculateSnappingPoints()
+	}
+
+	/**
+	 * Redraw the dynamic input lines overlay for multi-input logic gates.
+	 * Draws additional input lines between the existing top and bottom input lines
+	 * in the base SVG symbol to reflect the selected number of inputs.
+	 */
+	private redrawInputLines() {
+		this.inputLineGroup.clear()
+		if (!this.numberInputsProperty) return
+
+		const basePins = this.componentVariant.pins
+		const baseInputPins = basePins.filter((pin) => /^in \d+$/.test(pin.name))
+		if (baseInputPins.length < 2) return
+
+		const numInputs = parseInt(this.numberInputsProperty.value.key)
+		if (numInputs <= 2) return // 2-input uses the base symbol's lines directly
+
+		const sortedInputs = baseInputPins.sort((a, b) => a.point.y - b.point.y)
+		const xOffset = sortedInputs[0].point.x + this.componentVariant.mid.x
+		const minY = sortedInputs[0].point.y + this.componentVariant.mid.y
+		const maxY = sortedInputs[sortedInputs.length - 1].point.y + this.componentVariant.mid.y
+
+		// Draw only the intermediate lines (between top and bottom existing lines)
+		const lineLen = this.inputLineLength
+		for (let i = 1; i < numInputs - 1; i++) {
+			const t = i / (numInputs - 1)
+			const y = minY + t * (maxY - minY)
+			this.inputLineGroup
+				.line(xOffset, y, xOffset + lineLen, y)
+				.stroke({ color: defaultStroke, width: 0.53134 })
+		}
+	}
+
+	/**
+	 * Extract the input line length from the SVG symbol's path data.
+	 * This accounts for different gate styles having different input line geometries.
+	 */
+	private extractInputLineLength(): number {
+		const symbolElement = this.componentVariant.symbol.node
+		const pathElements = symbolElement.querySelectorAll("path")
+		for (const path of pathElements) {
+			const d = path.getAttribute("d")
+			if (!d) continue
+			// Prefer paths with the input-line stroke width (0.53134) over body paths
+			const sw = parseFloat(path.getAttribute("stroke-width") ?? "0")
+			const match = d.match(/h(-?\d+\.?\d*)/i)
+			if (match) {
+				const len = Math.abs(parseFloat(match[1]))
+				if (sw > 0.5 && sw < 0.6) {
+					return len // Input line path found
+				}
+			}
+		}
+		// Fallback: find any horizontal line in the SVG
+		for (const path of pathElements) {
+			const d = path.getAttribute("d")
+			if (!d) continue
+			const match = d.match(/h(-?\d+\.?\d*)/i)
+			if (match) {
+				return Math.abs(parseFloat(match[1]))
+			}
+		}
+		// Last resort: estimate from viewBox width
+		return this.componentVariant.viewBox.w * 0.15
 	}
 
 	protected recalculateSelectionVisuals(): void {
@@ -254,6 +409,9 @@ export class NodeSymbolComponent extends NodeComponent {
 		if (this.name.value) {
 			data.name = this.name.value
 		}
+		if (this.numberInputsProperty && this.numberInputsProperty.value.key !== "2") {
+			data.numberInputs = this.numberInputsProperty.value.key
+		}
 
 		return data
 	}
@@ -269,6 +427,12 @@ export class NodeSymbolComponent extends NodeComponent {
 
 	protected buildTikzCommand(command: TikzNodeCommand): void {
 		command.options.push(...this.referenceSymbol.optionsToStringArray(this.optionsFromProperties()))
+
+		// Add number inputs for multi-input logic gates
+		if (this.numberInputsProperty && this.numberInputsProperty.value.key !== "2") {
+			command.options.push(`number inputs=${this.numberInputsProperty.value.key}`)
+		}
+
 		super.buildTikzCommand(command)
 	}
 
@@ -277,6 +441,15 @@ export class NodeSymbolComponent extends NodeComponent {
 		let options = saveObject.options ?? []
 		this.setPropertiesFromOptions(this.referenceSymbol.getOptionsFromOptionNames(options))
 		this.scaleProperty.value = new SVG.Number(Math.abs(this.scaleState.x))
+
+		// Restore number of inputs for multi-input logic gates
+		if (this.numberInputsProperty && saveObject.numberInputs) {
+			const choice = this.numberInputsProperty.entries.find((e) => e.key === saveObject.numberInputs)
+			if (choice) {
+				this.numberInputsProperty.updateValue(choice, false, true)
+			}
+		}
+
 		this.update()
 		this.updateTheme()
 	}
@@ -306,6 +479,11 @@ export class NodeSymbolComponent extends NodeComponent {
 		let newComponent = new NodeSymbolComponent(this.referenceSymbol)
 		newComponent.rotationDeg = this.rotationDeg
 		newComponent.scaleState = new SVG.Point(this.scaleState)
+		if (this.numberInputsProperty && newComponent.numberInputsProperty) {
+			// Use updateValue without triggering listeners to avoid mode-switch side effects during placement
+			newComponent.numberInputsProperty.updateValue(this.numberInputsProperty.value, false, false)
+			newComponent.regenerateInputSnappingPoints()
+		}
 		return newComponent
 	}
 }


### PR DESCRIPTION
Previously, CircuitTikZ-Designer only supported 2-input logic gates. However, CircuiTikZ itself supports multi-input gates through the `number inputs` parameter.

This PR adds support for multi-input logic gates.
